### PR TITLE
Fixed issue when akka give default names to actor that include a dollar sign.

### DIFF
--- a/src/main/scala/com/tritondigital/counters/akka/ActorMetricsBase.scala
+++ b/src/main/scala/com/tritondigital/counters/akka/ActorMetricsBase.scala
@@ -1,7 +1,7 @@
 package com.tritondigital.counters.akka
 
 import akka.actor.Actor
-import com.tritondigital.counters.{Metrics, Tag}
+import com.tritondigital.counters.{Metric, Metrics, Tag}
 
 trait ActorMetricsBase extends Actor {
   protected def metrics: Metrics
@@ -20,7 +20,7 @@ trait ActorMetricsBase extends Actor {
         else
           message.getClass.getSimpleName
 
-      metrics.updateTimer("akka.actor.message", start, Tag("path", path), Tag("mclass", msgClass))
+      metrics.updateTimer("akka.actor.message", start, Tag("path", Metric.clean(path)), Tag("mclass", Metric.clean(msgClass)))
     }
   }
 }

--- a/src/test/scala/com/tritondigital/counters/akka/ActorMetricsTest.scala
+++ b/src/test/scala/com/tritondigital/counters/akka/ActorMetricsTest.scala
@@ -43,6 +43,20 @@ class ActorMetricsTest(_system: ActorSystem) extends TestKit(_system) with WordS
         UpdateTimerCall("akka.actor.message", 1, Seq(Tag("path", "/user/scala-actor"), Tag("mclass", "String")))
       )
     }
+    "publish actor message processing latencies when actor is named with special characters" in {
+      val metrics = new RecordingMetrics
+      val sut = system.actorOf(Props(new ScalaActor(metrics)), "@scala;-=actor+")
+
+      sut ! MessageValue
+
+      expectMsg(MessageValue)
+
+      Thread.sleep(200)
+
+      metrics.updateTimerCalls shouldBe Seq(
+        UpdateTimerCall("akka.actor.message", 1, Seq(Tag("path", "/user/scala-actor"), Tag("mclass", "String")))
+      )
+    }
   }
 
   class JavaActor(metrics: Metrics) extends ActorWithMetrics(metrics) {


### PR DESCRIPTION
Akka by default is giving names to actors that start with a dollar sign. Which is an invalid character for a tag value. Same issue with Scala class name, if the actor is a inner class.

Fixed the actor monitoring so the invalid characters are cleaned before updating the akka.actor.message timer.
